### PR TITLE
Add CHEST_DIR option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test-folder-*
+tests/.chest

--- a/chest
+++ b/chest
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # Create chest folder on first run
-mkdir -p ~/.chest
+[[ -z "${CHEST_DIR:-}" ]] && export CHEST_DIR="$HOME/.chest"
+mkdir -p "$CHEST_DIR"
 
 # Usage
 usage() {
@@ -55,7 +56,7 @@ encrypt() {
   else
     out_file=$key
   fi
-  out_file="${HOME}/.chest/${out_file}.tar"
+  out_file="$CHEST_DIR/${out_file}.tar"
   if [ $zip = true ]
   then
     out_file="${out_file}.gz"
@@ -119,16 +120,15 @@ decrypt() {
   key=$item
 
   # Get filepath
-  chest_dir="${HOME}/.chest"
   t=".tar.gpg"
   tgz=".tar.gz.gpg"
-  if [ -e "$chest_dir/$key$t" ]
+  if [ -e "$CHEST_DIR/$key$t" ]
   then
-    file_path="$chest_dir/$key$t"
+    file_path="$CHEST_DIR/$key$t"
   else
-    if [ -e "$chest_dir/$key$tgz" ]
+    if [ -e "$CHEST_DIR/$key$tgz" ]
     then
-      file_path="$chest_dir/$key$tgz"
+      file_path="$CHEST_DIR/$key$tgz"
     fi
   fi
 
@@ -165,11 +165,11 @@ list() {
   search=$item
 
   # Loop over all files in chest
-  chest_dir="${HOME}/.chest/*"
-  for file in $chest_dir; do
+  chest_files="$CHEST_DIR/*"
+  for file in $chest_files; do
 
     # Remove chest path
-    file=${file#$chest_dir}
+    file=${file#$chest_files}
 
     # Remove chest extensions
     key=false

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -9,7 +9,7 @@ load helper_functions
 
 @test "Check chest dir gets created" {
   run ./chest
-  [[ -d "$chest_dir" ]]
+  [[ -d "$CHEST_DIR" ]]
 }
 
 @test "Running with no commands should return usage with error status" {

--- a/tests/variables.bash
+++ b/tests/variables.bash
@@ -1,1 +1,1 @@
-CHEST_DIR="/tmp/.chest"
+CHEST_DIR="tests/.chest"

--- a/tests/variables.bash
+++ b/tests/variables.bash
@@ -1,1 +1,1 @@
-CHEST_DIR="tests/.chest"
+export CHEST_DIR="tests/.chest"

--- a/tests/variables.bash
+++ b/tests/variables.bash
@@ -1,1 +1,1 @@
-chest_dir="${HOME}/.chest"
+CHEST_DIR="/tmp/.chest"


### PR DESCRIPTION
Allows user to specify a custom chest dir with:

```shell
export CHEST_DIR="$HOME/.chest"
```

Useful for:
- Customising you chest install
- Moving your chest to a cloud backed folder (e.g Dropbox)
- Having multiple separate chests
- Running tests against a separate environment to your live install