### PR TITLE
Clear password cache

### DIFF
--- a/chest
+++ b/chest
@@ -1,8 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# Create chest folder on first run
+# Default options
 [[ -z "${CHEST_DIR:-}" ]] && export CHEST_DIR="$HOME/.chest"
+[[ -z "${CLEAR_PASSWORD_CACHE:-}" ]] && export CLEAR_PASSWORD_CACHE="true"
+
+# Create chest folder on first run
 mkdir -p "$CHEST_DIR"
 
 # Usage
@@ -92,6 +95,12 @@ encrypt() {
     exit 1
   fi
 
+  # Clear gpg password cache
+  if [ "$CLEAR_PASSWORD_CACHE" = "true" ]
+  then
+    gpgconf --reload gpg-agent
+  fi
+
   # Remove original
   if [ $remove = true ]
   then
@@ -144,6 +153,12 @@ decrypt() {
 
   # Retrieve from chest to current dir
   gpg -d $password_args "$file_path" | tar $args -
+
+  # Clear gpg password cache
+  if [ "$CLEAR_PASSWORD_CACHE" = "true" ]
+  then
+    gpgconf --reload gpg-agent
+  fi
 
 }
 


### PR DESCRIPTION
By default `gpg` saves passphrases during the current session, even for symmetric cryptography. That means once you encrypt something with a passphrase you can actually decrypt it right after without the passphrase.

This isn't a huge issue, it's convenient if you keep decrypting the same file and your data will be safe if someone accesses a remote backup. Even if it's accessed on the same machine, if the `gpg` agent has restarted since the last time the password was entered an attacker would still need to know the password.

However it does mean malicious software already running on the machine could gain access to the files without knowing the passwords (but only if the user had entered the password previously in the same session). Or more likely, if you leave you computer unlocked, someone could run up and decrypt any files you've already decrypted in your current session without needing your password.

It's an unlikely scenario but I'd rather protect against it so will default to restarting the `gpg` agent each time a password is entered, therefore ensuring no passwords will remain cached.

Users can override this if they want by setting:

```shell
export CLEAR_PASSWORD_CACHE="false"
```